### PR TITLE
recipes-utils/iot-gate-imx8plus-config: Don't use sudo when creating …

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-utils/iot-gate-imx8plus-config/iot-gate-imx8plus-config_git.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-utils/iot-gate-imx8plus-config/iot-gate-imx8plus-config_git.bbappend
@@ -1,4 +1,5 @@
 do_install:prepend () {
         mkdir -p ./lib/udev/rules.d
         mv ./etc/udev/rules.d/* ./lib/udev/rules.d/
+	sed -i "s/sudo/ /g" ./usr/local/bin/iotg-imx8plus-ie-config
 }


### PR DESCRIPTION
…ttyRS symlinks

The iotg-imx8plus-ie-config script failed to create ttyRS232_X and ttyRS485_Y symlinks because it was using sudo, which is not available in the balena rootfs.

The script is run as root anyway so let's remove sudo to avoid failure of creating the above mentioned links.

Changelog-entry: recipes-utils/iot-gate-imx8plus-config: Don't use sudo when creating ttyRS symlinks