### PR TITLE
initramfs-framework: iot-gate-imx8plus:remove migrator module

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,3 +1,4 @@
 PACKAGE_INSTALL:remove = "mdraid"
 PACKAGE_EXCLUDE = "kernel-image cryptodev-module"
 CORE_IMAGE_EXTRA_INSTALL:remove = " gpsd gps-utils connman wvdial ppp modemmanager "
+PACKAGE_INSTALL:remove:iot-gate-imx8plus = "initramfs-module-migrate"

--- a/layers/meta-balena-imx8mplus/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,4 @@
+PACKAGES:remove:iot-gate-imx8plus = "initramfs-module-migrate"
+do_install:append:iot-gate-imx8plus() {
+	rm -f ${D}/init.d/92-migrate
+}


### PR DESCRIPTION
The iot-gate-imx8plus is a particular device in that it defines an internal storage in the contract, but it does not use a flasher image and instead relies on the bootloader's ums exposing the internal storage.

However, resin-init-flasher has a built time check for all devices that define internal storage to define INTERNAL_DEVICE_KERNEL, so the build fails when initramfs-framework builds the resin-init-flasher dependency.

The lack of a `jq` dependency on earlier versions of meta-balena meant that the check was non-operative, but it started failing when the dependency was added.

This commit removes the migrator module from being built and included in the initramfs.

Changelog-entry: remove migrator module for iot-gate-imx8plus