### PR TITLE
u-boot-compulab: Rebase defconfig changes

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-bsp/u-boot/patches/0005-configs-Boot-balena-directly.patch
+++ b/layers/meta-balena-imx8mplus/recipes-bsp/u-boot/patches/0005-configs-Boot-balena-directly.patch
@@ -1,6 +1,6 @@
-From dbfcfac5f047e0346ab6d9a3cd5717028492a707 Mon Sep 17 00:00:00 2001
+From eba81e0049f9023b7d3adc7f367c650770adae7f Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
-Date: Fri, 24 Feb 2023 11:32:48 +0100
+Date: Tue, 19 Dec 2023 07:14:48 +0000
 Subject: [PATCH] configs: Boot balena directly
 
 Avoid wasting boot time when searching for usb
@@ -9,11 +9,11 @@ devices and such and boot directly from the eMMC
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
- configs/iot-gate-imx8plus_defconfig | 7 ++++---
- 1 file changed, 4 insertions(+), 3 deletions(-)
+ configs/iot-gate-imx8plus_defconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/configs/iot-gate-imx8plus_defconfig b/configs/iot-gate-imx8plus_defconfig
-index 46b5b70afc..7a6b2b0a42 100644
+index 11d428ac8a..d628a1e318 100644
 --- a/configs/iot-gate-imx8plus_defconfig
 +++ b/configs/iot-gate-imx8plus_defconfig
 @@ -6,7 +6,7 @@ CONFIG_SPL_LIBCOMMON_SUPPORT=y
@@ -25,29 +25,15 @@ index 46b5b70afc..7a6b2b0a42 100644
  CONFIG_ENV_OFFSET=0x3F0000
  CONFIG_SYS_I2C_MXC_I2C1=y
  CONFIG_SYS_I2C_MXC_I2C2=y
-@@ -29,7 +29,7 @@ CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"
+@@ -25,7 +25,7 @@ CONFIG_SPL_LOAD_FIT=y
  CONFIG_OF_BOARD_SETUP=y
  CONFIG_OF_SYSTEM_SETUP=y
  CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mp-lpddr4.cfg"
 -CONFIG_BOOTCOMMAND="run distro_bootcmd;run bsp_bootcmd"
-+CONFIG_BOOTCOMMAND="run bsp_bootcmd;"
- CONFIG_DEFAULT_FDT_FILE="iot-gate-imx8plus.dtb"
++CONFIG_BOOTCOMMAND="run bsp_bootcmd"
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_BOARD_EARLY_INIT_F=y
-@@ -65,7 +65,7 @@ CONFIG_CMD_REGULATOR=y
- CONFIG_CMD_EXT4_WRITE=y
- CONFIG_OF_CONTROL=y
- CONFIG_SPL_OF_CONTROL=y
--CONFIG_ENV_IS_IN_MMC=y
-+CONFIG_ENV_IS_IN_MMC=y
- CONFIG_SYS_RELOC_GD_ENV_ADDR=y
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_SPL_DM=y
-@@ -164,3 +164,4 @@ CONFIG_PARTITION_UUIDS=y
- CONFIG_CMD_PART=y
- CONFIG_CMD_FS_UUID=y
- CONFIG_CMD_USB_MASS_STORAGE
-+CONFIG_SYS_MMC_ENV_DEV=0
+ CONFIG_BOARD_LATE_INIT=y
 -- 
-2.37.2
+2.17.1
 


### PR DESCRIPTION
because upstream uses AUTOREV and has modified
the defconfig in which we set CONFIG_BOOTCOMMAND
and increase the ENV_SIZE

Changelog-entry: u-boot-compulab: Rebase defconfig changes