### PR TITLE
linux: recover support for TPM module

### DIFF
--- a/layers/meta-balena-imx8mplus/conf/layer.conf
+++ b/layers/meta-balena-imx8mplus/conf/layer.conf
@@ -23,6 +23,12 @@ BBMASK += "meta-compulab-bsp/meta-bsp/recipes-bsp/u-boot-update-scr"
 KERNEL_IMAGETYPE:iot-gate-imx8plus = "Image.gz"
 KERNEL_PACKAGE_NAME="kernel"
 
+KERNEL_DEVICETREE:iot-gate-imx8plus = " \
+       compulab/iot-gate-imx8plus.dtb \
+       compulab/iot-gate-imx8plus-usbdev.dtb \
+       compulab/iot-gate-imx8plus-m2tpm.dtb \
+"
+
 DRAM_CONF:iot-gate-imx8plus="d2d4"
 DRAM_CONF:iot-gate-imx8plus-d1d8="d1d8"
 

--- a/layers/meta-balena-imx8mplus/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8mplus/recipes-core/images/balena-image.inc
@@ -2,10 +2,11 @@ IMAGE_FSTYPES:append = " balenaos-img"
 
 dram_conf = "${@bb.utils.contains('DRAM_CONF', 'd2d4', 'd2d4', 'd1d8', d)}"
 
+KERNEL_DEVICE_TREES = "${@' '.join(map(str, [os.path.join('balena-bootloader', os.path.basename(dt) + ':/' + os.path.basename(dt)) for dt in d.getVar('KERNEL_DEVICETREE').split()]))}"
+
 BALENA_BOOT_PARTITION_FILES += " \
     imx-boot_${MACHINE}_${dram_conf}:/imx-boot-${MACHINE}-sd.bin-flash_evk \
-    balena-bootloader/iot-gate-imx8plus-usbdev.dtb:/iot-gate-imx8plus-usbdev.dtb \
-    balena-bootloader/iot-gate-imx8plus.dtb:/iot-gate-imx8plus.dtb \
+    ${KERNEL_DEVICE_TREES} \
     balena-bootloader/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
     balena-bootloader/bootenv:/bootenv \
 "

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0055-compulab-iot-gate-imx8plus-add-support-for-TPM.patch
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0055-compulab-iot-gate-imx8plus-add-support-for-TPM.patch
@@ -1,0 +1,110 @@
+From ce2773f1ef518603ce7c8ca238b2c570e34b9fdd Mon Sep 17 00:00:00 2001
+From: Ilya Ledvich <ilya@compulab.co.il>
+Date: Fri, 25 Nov 2022 16:19:32 +0200
+Subject: [PATCH] compulab: iot-gate-imx8plus: add support for TPM
+
+Add support for TPM extension module in M.2 Expansion Connector (aka M2TPM).
+The M2TPM module features SLB9670 Trusted Platform Module by Infineon over SPI.
+
+Signed-off-by: Ilya Ledvich <ilya@compulab.co.il>
+---
+ arch/arm64/boot/dts/compulab/Makefile         |  1 +
+ .../dts/compulab/iot-gate-imx8plus-m2tpm.dts  | 61 +++++++++++++++++++
+ .../arm64/configs/iot-gate-imx8plus_defconfig |  1 +
+ 3 files changed, 63 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m2tpm.dts
+
+diff --git a/arch/arm64/boot/dts/compulab/Makefile b/arch/arm64/boot/dts/compulab/Makefile
+index 4fbb26d4bcec..60205dd04b1f 100644
+--- a/arch/arm64/boot/dts/compulab/Makefile
++++ b/arch/arm64/boot/dts/compulab/Makefile
+@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARCH_MXC) += ucm-imx8m-plus-uart1.dtb
+ dtb-$(CONFIG_ARCH_MXC) += ucm-imx8m-plus-headless.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-usbdev.dtb
++dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-m2tpm.dtb
+ 
+ dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus.dtb
+ dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus_mipi-csi1.dtb
+diff --git a/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m2tpm.dts b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m2tpm.dts
+new file mode 100644
+index 000000000000..f1e94e21e904
+--- /dev/null
++++ b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m2tpm.dts
+@@ -0,0 +1,61 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2022 CompuLab Ltd
++ */
++
++#include "iot-gate-imx8plus.dts"
++
++/* IOT-GATE-IMX8PLUS with TPM extension module in M.2 Expansion Connector */
++
++/ {
++	tpm_nreset: tpm-nreset {
++		compatible = "gpio-reset";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm_nrst>;
++		reset-gpios = <&gpio3 20 GPIO_ACTIVE_HIGH>;
++		#reset-cells = <0>;
++		initially-in-reset;
++	};
++};
++
++&ecspi2 {
++	status = "okay";
++
++	/delete-node/ spidev2@0;
++
++	slb9670: slb9670-ecspi2@0 {
++		resets = <&tpm_nreset>;
++		compatible = "infineon,slb9670", "tcg,tpm_tis-spi";
++		reg = <0>;
++		spi-max-frequency = <5000000>;
++		status = "okay";
++	};
++};
++
++&i2c5 {
++	status = "okay";
++
++	eeprom_m2: eeprom-i2c5@54 {
++		compatible = "atmel,24c08";
++		pagesize = <16>;
++		reg = <0x54>;
++		status = "okay";
++	};
++};
++
++&i2c6 {
++	status = "disabled";
++};
++
++&usdhc2 {
++	status = "disabled";
++};
++
++&iomuxc {
++	pinctrl_tpm_nrst: tpmnrstgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXC__GPIO3_IO20			0x19
++		>;
++	};
++};
++
+diff --git a/arch/arm64/configs/iot-gate-imx8plus_defconfig b/arch/arm64/configs/iot-gate-imx8plus_defconfig
+index d72dc869651c..575741d2e1e8 100644
+--- a/arch/arm64/configs/iot-gate-imx8plus_defconfig
++++ b/arch/arm64/configs/iot-gate-imx8plus_defconfig
+@@ -683,6 +683,7 @@ CONFIG_HW_RANDOM_TIMERIOMEM=m
+ CONFIG_HW_RANDOM_BA431=m
+ CONFIG_HW_RANDOM_VIRTIO=m
+ CONFIG_TCG_TPM=y
++CONFIG_TCG_TIS_SPI=m
+ CONFIG_TCG_TIS_I2C_INFINEON=y
+ CONFIG_I2C_CHARDEV=y
+ CONFIG_I2C_MUX=y
+-- 
+2.20.1
+

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append = " \
     file://soc-imx8m-Enable-OCOTP-clock-before-reading-the-regi.patch \
     file://soc-imx8m-Fix-incorrect-check-for-of_clk_get_by_name.patch \
     file://soc-imx8m-Enable-OCOTP-clock-for-imx8mm-before-readi.patch \
+    file://0055-compulab-iot-gate-imx8plus-add-support-for-TPM.patch  \
 "
 
 # Fixes issue where cryptodev module is installed


### PR DESCRIPTION
The linux-compulab 5.15.35 contained support for the TPM module that goes into the M.2 slot. The update to 5.15.71 dropped this support.

This commit re-introduces support for this TPM module in both linux-compulab and linux-balena-bootloader.

Changelog-entry: recover support for TPM module