### PR TITLE
linux-compulab_%.bbappend:  Package modules using nonarch_base_libdir…

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -56,3 +56,6 @@ do_merge_config_before_resin_inject () {
 }
 
 addtask do_merge_config_before_resin_inject after do_configure before kernel_resin_injectconfig
+
+# meta-bsp-imx8mp explicitly packages for /lib so let's also append the path set by nonarch_base_libdir for future use of usrmerge
+FILES:${KERNEL_PACKAGE_NAME}-modules += "${nonarch_base_libdir}/modules/"


### PR DESCRIPTION
… variable

Use a variable to select from where to package the kernel modules from instead of hardcoding this path. This is going to be of use when we enable the usrmerge feature.

Changelog-entry: Package the kernel modules using the nonarch_base_libdir variable instead of hardcoding the path to the modules