### PR TITLE
optee-os_%.bbappend: Fixes for usrmerge feature

### DIFF
--- a/layers/meta-balena-imx8mplus/recipes-security/optee-imx/optee-os_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-security/optee-imx/optee-os_%.bbappend
@@ -1,0 +1,2 @@
+# package files as needed by the usrmerge feature
+FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/"


### PR DESCRIPTION
Changelog-entry: Package the optee-os files using the nonarch_base_libdir variable instead of hardcoding the path to the files