### PR TITLE
workflows: iot-gate-imx8plus-sb: remove non-sb runs

### DIFF
--- a/.github/workflows/iot-gate-imx8plus-sb.yml
+++ b/.github/workflows/iot-gate-imx8plus-sb.yml
@@ -65,7 +65,7 @@ jobs:
           "environment": ["balena-cloud.com"],
           "worker_type": ["testbot"],
           "runs_on": [["ubuntu-latest"]],
-          "secure_boot": ["sb",""]
+          "secure_boot": ["sb"]
         }
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}


### PR DESCRIPTION
Closed i.MX devices are not able to run non secure-boot opt-in installers.

Changelog-entry: remove non-sb test runs for iot-gate-imx8plus-sb