### PR TITLE
Fix wireless regdb not being loaded

### DIFF
--- a/layers/meta-balena-imx8mplus/conf/layer.conf
+++ b/layers/meta-balena-imx8mplus/conf/layer.conf
@@ -39,3 +39,9 @@ HOSTTOOLS:remove = " git-lfs "
 HOSTTOOLS:remove = " bison "
 MACHINE_FEATURES:remove = "optee-os"
 MACHINE_FEATURES:remove = "efi"
+
+# This is the version provided by the poky
+# revision for the 5.15 kernel revision, as per https://github.com/nxp-imx/imx-manifest/blob/imx-linux-kirkstone/imx-5.15.32-2.0.0.xml
+# Can be dropped after updating to a newer kernel which
+# is in sync with the wireless regdb provided by Poky
+PREFERRED_VERSION:wireless-regdb = "2022.04.08"

--- a/layers/meta-balena-imx8mplus/recipes-kernel/wireless-regdb/wireless-regdb_2022.04.08.bb
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/wireless-regdb/wireless-regdb_2022.04.08.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Wireless Central Regulatory Domain Database"
+HOMEPAGE = "https://wireless.wiki.kernel.org/en/developers/regulatory/crda"
+SECTION = "net"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=07c4f6dea3845b02a18dc00c8c87699c"
+
+SRC_URI = "https://www.kernel.org/pub/software/network/${BPN}/${BP}.tar.xz"
+SRC_URI[sha256sum] = "884ba2e3c1e8b98762b6dc25ff60b5ec75c8d33a39e019b3ed4aa615491460d3"
+
+inherit bin_package allarch
+
+do_install() {
+    install -d -m0755 ${D}${nonarch_libdir}/crda
+    install -d -m0755 ${D}${sysconfdir}/wireless-regdb/pubkeys
+    install -m 0644 regulatory.bin ${D}${nonarch_libdir}/crda/regulatory.bin
+    install -m 0644 sforshee.key.pub.pem ${D}${sysconfdir}/wireless-regdb/pubkeys/sforshee.key.pub.pem
+
+    install -m 0644 -D regulatory.db ${D}${nonarch_base_libdir}/firmware/regulatory.db
+    install -m 0644 regulatory.db.p7s ${D}${nonarch_base_libdir}/firmware/regulatory.db.p7s
+}
+
+# Install static regulatory DB in /lib/firmware for kernel to load.
+# This requires Linux kernel >= v4.15.
+# For kernel <= v4.14, inherit the kernel_wireless_regdb.bbclass
+# (in meta-networking) in kernel's recipe.
+PACKAGES = "${PN}-static ${PN}"
+RCONFLICTS:${PN} = "${PN}-static"
+
+FILES:${PN}-static = " \
+    ${nonarch_base_libdir}/firmware/regulatory.db \
+    ${nonarch_base_libdir}/firmware/regulatory.db.p7s \
+"
+
+# Native users might want to use the source of regulatory DB.
+# This is for example used by Linux kernel <= v4.14 and
+# kernel_wireless_regdb.bbclass in meta-networking.
+do_install:append:class-native() {
+    install -m 0644 -D db.txt ${D}${libdir}/crda/db.txt
+}
+
+RSUGGESTS:${PN} = "crda"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This PR fixes the following error visible in dmesg:

```
cfg80211: loaded regulatory.db is malformed or signature is missing/invalid
```

