### PR TITLE
layers/meta-compulab-bsp: Switch to kirkstone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "layers/meta-compulab-bsp"]
 	path = layers/meta-compulab-bsp
 	url = https://github.com/compulab-yokneam/meta-compulab-bsp
-	branch = honister
+	branch = kirkstone
 [submodule "layers/meta-freescale"]
 	path = layers/meta-freescale
 	url = https://github.com/Freescale/meta-freescale/


### PR DESCRIPTION
The hw vendor has now created a kirkstone branch so let's use it

Changelog-entry: Switch meta-compulab-bsp to kirkstone