### PR TITLE
machine: Clarify DRAM sizes in device names

### DIFF
--- a/iot-gate-imx8plus-d1d8.coffee
+++ b/iot-gate-imx8plus-d1d8.coffee
@@ -10,7 +10,7 @@ postProvisioningInstructions = [
 module.exports =
         version: 1
         slug: 'iot-gate-imx8plus-d1d8'
-        name: 'Compulab IOT-GATE-iMX8PLUS 1G-8G DRAM'
+        name: 'Compulab IOT-GATE-iMX8PLUS 1GB or 8GB DRAM'
         arch: 'aarch64'
         state: 'released'
  

--- a/iot-gate-imx8plus-sb.coffee
+++ b/iot-gate-imx8plus-sb.coffee
@@ -10,7 +10,7 @@ postProvisioningInstructions = [
 module.exports =
         version: 1
         slug: 'iot-gate-imx8plus-sb'
-        name: 'Compulab IOT-GATE-iMX8PLUS 2G-4G DRAM secure boot variant'
+        name: 'Compulab IOT-GATE-iMX8PLUS 2GB or 4GB DRAM secure boot variant'
         arch: 'aarch64'
         state: 'released'
  

--- a/iot-gate-imx8plus.coffee
+++ b/iot-gate-imx8plus.coffee
@@ -10,7 +10,7 @@ postProvisioningInstructions = [
 module.exports =
         version: 1
         slug: 'iot-gate-imx8plus'
-        name: 'Compulab IOT-GATE-iMX8PLUS 2G-4G DRAM'
+        name: 'Compulab IOT-GATE-iMX8PLUS 2GB or 4GB DRAM'
         arch: 'aarch64'
         state: 'released'
  


### PR DESCRIPTION
Update the device names in the configuration files to explicitly state the RAM variants (e.g. changing from hyphenated ranges like "1G-8G" to explicit sizes like "1GB or 8GB"). This improves clarity for users.

Changelog-entry: machine: Clarify DRAM sizes in device names