### PR TITLE
71mhz pixel clock and addtional dts

### DIFF
--- a/layers/meta-balena-imx8mplus/conf/layer.conf
+++ b/layers/meta-balena-imx8mplus/conf/layer.conf
@@ -33,6 +33,7 @@ KERNEL_DEVICETREE:iot-gate-imx8plus = " \
        compulab/iot-gate-imx8plus-usbdev.dtb \
        compulab/iot-gate-imx8plus-m2tpm.dtb \
        compulab/iot-gate-imx8plus-m7.dtb \
+       compulab/iot-gate-imx8plus-mdpcb-m2tpm.dtb \
 "
 
 DRAM_CONF:iot-gate-imx8plus="d2d4"

--- a/layers/meta-balena-imx8mplus/conf/layer.conf
+++ b/layers/meta-balena-imx8mplus/conf/layer.conf
@@ -25,6 +25,8 @@ BBMASK += "meta-compulab-bsp/meta-bsp/recipes-bsp/u-boot-update-scr"
 BBMASK += "meta-balena-hab/recipes-bsp/u-boot/u-boot-variscite.bbappend"
 BBMASK += "meta-balena-hab/recipes-kernel/linux/linux-variscite_%.bbappend"
 
+BBMASK += "meta-imx/meta-bsp/recipes-connectivity/openssl/openssl"
+
 KERNEL_IMAGETYPE:iot-gate-imx8plus = "Image.gz"
 KERNEL_PACKAGE_NAME="kernel"
 

--- a/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/0001-e_devcrypto-add-func-ptr-for-init-do-ctrl.patch
+++ b/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/0001-e_devcrypto-add-func-ptr-for-init-do-ctrl.patch
@@ -1,0 +1,101 @@
+From d6c1bf7031cbd96c1d0dec589f318ad942107d23 Mon Sep 17 00:00:00 2001
+From: Pankaj Gupta <pankaj.gupta@nxp.com>
+Date: Tue, 18 Jan 2022 17:37:37 +0530
+Subject: [PATCH 1/2] e_devcrypto: add func ptr for init, do, ctrl
+
+In engine "devcrypto", as part prepare_cipher_methods()
+- Added function pointer for init, do, ctrl and
+  variable "flags" such that:
+- New cipher can override them to support offloads
+  to h/w via devcrypto.
+
+Upstream-Status: Pending [i.MX, Layerscape specific]
+Signed-off-by: Pankaj Gupta <pankaj.gupta@nxp.com>
+
+---
+ engines/e_devcrypto.c | 30 ++++++++++++++++++++++--------
+ 1 file changed, 22 insertions(+), 8 deletions(-)
+
+diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
+index 8274fc3..0c63fd1 100644
+--- a/engines/e_devcrypto.c
++++ b/engines/e_devcrypto.c
+@@ -402,6 +402,11 @@ static EVP_CIPHER *known_cipher_methods[OSSL_NELEM(cipher_data)] = {
+ };
+ static int selected_ciphers[OSSL_NELEM(cipher_data)];
+ static struct driver_info_st cipher_driver_info[OSSL_NELEM(cipher_data)];
++int (*init)(EVP_CIPHER_CTX *ctx, const unsigned char *key,
++                const unsigned char *iv, int enc);
++int (*do_cipher)(EVP_CIPHER_CTX *ctx, unsigned char *out,
++                const unsigned char *in, size_t inl);
++int (*ctrl)(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
+ 
+ static int devcrypto_test_cipher(size_t cipher_data_index)
+ {
+@@ -420,6 +425,7 @@ static void prepare_cipher_methods(void)
+     size_t i;
+     session_op_t sess;
+     unsigned long cipher_mode;
++    unsigned long flags;
+ #ifdef CIOCGSESSION2
+     struct crypt_find_op fop;
+     enum devcrypto_accelerated_t accelerated;
+@@ -431,16 +437,25 @@ static void prepare_cipher_methods(void)
+ 
+     memset(&sess, 0, sizeof(sess));
+     sess.key = (void *)"01234567890123456789012345678901234567890123456789";
++    sess.mackey = (void *)"123456789ABCDEFGHIJKLMNO";
+ 
+     for (i = 0, known_cipher_nids_amount = 0;
+         i < OSSL_NELEM(cipher_data); i++) {
+ 
+         selected_ciphers[i] = 1;
++	init  = cipher_init;
++        ctrl  = cipher_ctrl;
++        flags = cipher_data[i].flags
++                | EVP_CIPH_CUSTOM_COPY
++                | EVP_CIPH_CTRL_INIT
++                | EVP_CIPH_FLAG_DEFAULT_ASN1;
++
+         /*
+          * Check that the cipher is usable
+          */
+         sess.cipher = cipher_data[i].devcryptoid;
+         sess.keylen = cipher_data[i].keylen;
++
+ #ifdef CIOCGSESSION2
+         /*
+          * When using CIOCGSESSION2, first try to allocate a hardware
+@@ -466,7 +481,9 @@ static void prepare_cipher_methods(void)
+ #endif
+ 
+         cipher_mode = cipher_data[i].flags & EVP_CIPH_MODE;
+-
++        do_cipher = (cipher_mode == EVP_CIPH_CTR_MODE ?
++                                              ctr_do_cipher :
++                                              cipher_do_cipher);
+         if ((known_cipher_methods[i] = EVP_CIPHER_meth_new(cipher_data[i].nid,
+                  cipher_mode == EVP_CIPH_CTR_MODE ? 1 : cipher_data[i].blocksize,
+                  cipher_data[i].keylen))
+@@ -474,14 +491,11 @@ static void prepare_cipher_methods(void)
+             || !EVP_CIPHER_meth_set_iv_length(known_cipher_methods[i],
+                 cipher_data[i].ivlen)
+             || !EVP_CIPHER_meth_set_flags(known_cipher_methods[i],
+-                cipher_data[i].flags
+-                    | EVP_CIPH_CUSTOM_COPY
+-                    | EVP_CIPH_CTRL_INIT
+-                    | EVP_CIPH_FLAG_DEFAULT_ASN1)
+-            || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], cipher_init)
++                                          flags)
++            || !EVP_CIPHER_meth_set_init(known_cipher_methods[i], init)
+             || !EVP_CIPHER_meth_set_do_cipher(known_cipher_methods[i],
+-                cipher_mode == EVP_CIPH_CTR_MODE ? ctr_do_cipher : cipher_do_cipher)
+-            || !EVP_CIPHER_meth_set_ctrl(known_cipher_methods[i], cipher_ctrl)
++                                              do_cipher)
++            || !EVP_CIPHER_meth_set_ctrl(known_cipher_methods[i], ctrl)
+             || !EVP_CIPHER_meth_set_cleanup(known_cipher_methods[i],
+                 cipher_cleanup)
+             || !EVP_CIPHER_meth_set_impl_ctx_size(known_cipher_methods[i],
+-- 
+2.34.1
+

--- a/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/0002-e_devcrypto-add-support-for-TLS1.2-algorithms-offloa.patch
+++ b/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/0002-e_devcrypto-add-support-for-TLS1.2-algorithms-offloa.patch
@@ -1,0 +1,379 @@
+From 19f69fdfa94f16ae4f824968a9e6e0d4bfaf9d7e Mon Sep 17 00:00:00 2001
+From: Pankaj Gupta <pankaj.gupta@nxp.com>
+Date: Tue, 18 Jan 2022 17:38:11 +0530
+Subject: [PATCH 2/2] e_devcrypto: add support for TLS1.2 algorithms offload
+
+    - aes-128-cbc-hmac-sha256
+    - aes-256-cbc-hmac-sha256
+
+Enabled the support of TLS1.1 algorithms offload
+
+    - aes-128-cbc-hmac-sha1
+    - aes-256-cbc-hmac-sha1
+
+TLS algorithm support in CAAM Linux kernel driver.
+
+Fix: Remove the support for TLS1.0.
+
+Upstream-Status: Pending [i.MX, Layerscape specific]
+Signed-off-by: Pankaj Gupta <pankaj.gupta@nxp.com>
+
+---
+ engines/e_devcrypto.c | 272 ++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 248 insertions(+), 24 deletions(-)
+
+diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
+index 0c63fd1..0fd87d8 100644
+--- a/engines/e_devcrypto.c
++++ b/engines/e_devcrypto.c
+@@ -27,6 +27,7 @@
+ #include "crypto/cryptodev.h"
+ 
+ /* #define ENGINE_DEVCRYPTO_DEBUG */
++#define TLS1_1_VERSION  0x0302
+ 
+ #if CRYPTO_ALGORITHM_MIN < CRYPTO_ALGORITHM_MAX
+ #define CHECK_BSD_STYLE_MACROS
+@@ -107,10 +108,14 @@ struct cipher_ctx {
+     session_op_t sess;
+     int op; /* COP_ENCRYPT or COP_DECRYPT */
+     unsigned long mode; /* EVP_CIPH_*_MODE */
++    unsigned char *aad;
++    unsigned int aad_len;
++    unsigned int len;
+ 
+     /* to handle ctr mode being a stream cipher */
+     unsigned char partial[EVP_MAX_BLOCK_LENGTH];
+     unsigned int blocksize, num;
++    unsigned int tls_ver;
+ };
+ 
+ static const struct cipher_data_st {
+@@ -120,49 +125,66 @@ static const struct cipher_data_st {
+     int ivlen;
+     int flags;
+     int devcryptoid;
++    int mackeylen;
+ } cipher_data[] = {
+ #ifndef OPENSSL_NO_DES
+-    { NID_des_cbc, 8, 8, 8, EVP_CIPH_CBC_MODE, CRYPTO_DES_CBC },
+-    { NID_des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE, CRYPTO_3DES_CBC },
++    { NID_des_cbc, 8, 8, 8, EVP_CIPH_CBC_MODE, CRYPTO_DES_CBC, 0 },
++    { NID_des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE, CRYPTO_3DES_CBC, 0 },
+ #endif
+ #ifndef OPENSSL_NO_BF
+-    { NID_bf_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_BLF_CBC },
++    { NID_bf_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_BLF_CBC, 0 },
+ #endif
+ #ifndef OPENSSL_NO_CAST
+-    { NID_cast5_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_CAST_CBC },
++    { NID_cast5_cbc, 8, 16, 8, EVP_CIPH_CBC_MODE, CRYPTO_CAST_CBC, 0 },
+ #endif
+-    { NID_aes_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
+-    { NID_aes_192_cbc, 16, 192 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
+-    { NID_aes_256_cbc, 16, 256 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC },
++    { NID_aes_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC, 0 },
++    { NID_aes_192_cbc, 16, 192 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC, 0 },
++    { NID_aes_256_cbc, 16, 256 / 8, 16, EVP_CIPH_CBC_MODE, CRYPTO_AES_CBC, 0 },
++    { NID_aes_128_cbc_hmac_sha1, 16, 16, 16,
++            EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_AEAD_CIPHER,
++            CRYPTO_TLS11_AES_CBC_HMAC_SHA1, 20 },
++    { NID_aes_256_cbc_hmac_sha1, 16, 32, 16,
++            EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_AEAD_CIPHER,
++            CRYPTO_TLS11_AES_CBC_HMAC_SHA1, 20 },
++    { NID_aes_128_cbc_hmac_sha256, 16, 16, 16,
++           EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_AEAD_CIPHER,
++           CRYPTO_TLS12_AES_CBC_HMAC_SHA256, 32 },
++    { NID_aes_256_cbc_hmac_sha256, 16, 32, 16,
++           EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_AEAD_CIPHER,
++           CRYPTO_TLS12_AES_CBC_HMAC_SHA256, 32 },
+ #ifndef OPENSSL_NO_RC4
+-    { NID_rc4, 1, 16, 0, EVP_CIPH_STREAM_CIPHER, CRYPTO_ARC4 },
++    { NID_rc4, 1, 16, 0, EVP_CIPH_STREAM_CIPHER, CRYPTO_ARC4, 0 },
+ #endif
+ #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_CTR)
+-    { NID_aes_128_ctr, 16, 128 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
+-    { NID_aes_192_ctr, 16, 192 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
+-    { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
++    { NID_aes_128_ctr, 16, 128 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR, 0 },
++    { NID_aes_192_ctr, 16, 192 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR, 0 },
++    { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR, 0 },
+ #endif
+ #if 0 /* Not yet supported */
+-    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
+-    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
++    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS, 0 },
++    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS, 0 },
+ #endif
+ #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
+-    { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+-    { NID_aes_192_ecb, 16, 192 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
+-    { NID_aes_256_ecb, 16, 256 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
++    { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB, 0 },
++    { NID_aes_192_ecb, 16, 192 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB, 0 },
++    { NID_aes_256_ecb, 16, 256 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB, 0 },
+ #endif
+ #if 0 /* Not yet supported */
+-    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+-    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+-    { NID_aes_256_gcm, 16, 256 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
++    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM, 0 },
++    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM, 0 },
++    { NID_aes_256_gcm, 16, 256 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM, 0 },
++#endif
++#ifdef OPENSSL_NXP_CAAM
++    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM, 0 },
++    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM, 0 }
+ #endif
+ #ifndef OPENSSL_NO_CAMELLIA
+     { NID_camellia_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE,
+-        CRYPTO_CAMELLIA_CBC },
++        CRYPTO_CAMELLIA_CBC, 0 },
+     { NID_camellia_192_cbc, 16, 192 / 8, 16, EVP_CIPH_CBC_MODE,
+-        CRYPTO_CAMELLIA_CBC },
++        CRYPTO_CAMELLIA_CBC, 0 },
+     { NID_camellia_256_cbc, 16, 256 / 8, 16, EVP_CIPH_CBC_MODE,
+-        CRYPTO_CAMELLIA_CBC },
++        CRYPTO_CAMELLIA_CBC, 0 },
+ #endif
+ };
+ 
+@@ -197,6 +219,193 @@ static const struct cipher_data_st *get_cipher_data(int nid)
+     return &cipher_data[get_cipher_data_index(nid)];
+ }
+ 
++/*
++ * Save the encryption key provided by upper layers. This function is called
++ * by EVP_CipherInit_ex to initialize the algorithm's extra data. We can't do
++ * much here because the mac key is not available. The next call should/will
++ * be to cryptodev_cbc_hmac_sha1_ctrl with parameter
++ * EVP_CTRL_AEAD_SET_MAC_KEY, to set the hmac key. There we call CIOCGSESSION
++ * with both the crypto and hmac keys.
++ */
++static int cryptodev_init_aead_key(EVP_CIPHER_CTX *ctx,
++                const unsigned char *key, const unsigned char *iv, int enc)
++{
++    struct cipher_ctx *state = EVP_CIPHER_CTX_get_cipher_data(ctx);
++    struct session_op *sess = &state->sess;
++    int cipher = -1, i;
++
++    for (i = 0; cipher_data[i].devcryptoid; i++) {
++        if (EVP_CIPHER_CTX_nid(ctx) == cipher_data[i].nid &&
++            EVP_CIPHER_CTX_iv_length(ctx) <= cipher_data[i].ivlen &&
++            EVP_CIPHER_CTX_key_length(ctx) == cipher_data[i].keylen) {
++            cipher = cipher_data[i].devcryptoid;
++            break;
++        }
++    }
++
++    if (!cipher_data[i].devcryptoid)
++        return (0);
++
++    memset(sess, 0, sizeof(*sess));
++
++    sess->key = (void *) key;
++    sess->keylen = EVP_CIPHER_CTX_key_length(ctx);
++    sess->cipher = cipher;
++
++    /* for whatever reason, (1) means success */
++    return 1;
++}
++
++static int cryptodev_aead_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
++                                 const unsigned char *in, size_t len)
++{
++    struct crypt_auth_op cryp;
++    struct cipher_ctx *state = EVP_CIPHER_CTX_get_cipher_data(ctx);
++    struct session_op *sess = &state->sess;
++    const void *iiv;
++    unsigned char save_iv[EVP_MAX_IV_LENGTH];
++
++    if (cfd < 0)
++        return (0);
++    if (!len)
++        return (1);
++    if ((len % EVP_CIPHER_CTX_block_size(ctx)) != 0)
++        return (0);
++
++    memset(&cryp, 0, sizeof(cryp));
++
++    if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
++        if (!EVP_CIPHER_CTX_encrypting(ctx)) {
++            iiv = in + len - EVP_CIPHER_CTX_iv_length(ctx);
++            memcpy(save_iv, iiv, EVP_CIPHER_CTX_iv_length(ctx));
++
++            if (state->tls_ver >= TLS1_1_VERSION) {
++                memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), in,
++                       EVP_CIPHER_CTX_iv_length(ctx));
++                in += EVP_CIPHER_CTX_iv_length(ctx);
++                out += EVP_CIPHER_CTX_iv_length(ctx);
++                len -= EVP_CIPHER_CTX_iv_length(ctx);
++            }
++        }
++        cryp.iv = (void *) EVP_CIPHER_CTX_iv(ctx);
++    } else
++        cryp.iv = NULL;
++
++    /* TODO: make a seamless integration with cryptodev flags */
++    switch (EVP_CIPHER_CTX_nid(ctx)) {
++    case NID_aes_128_cbc_hmac_sha1:
++    case NID_aes_256_cbc_hmac_sha1:
++    case NID_aes_128_cbc_hmac_sha256:
++    case NID_aes_256_cbc_hmac_sha256:
++        cryp.flags = COP_FLAG_AEAD_TLS_TYPE;
++    }
++    cryp.ses = sess->ses;
++    cryp.len = state->len;
++    cryp.src = (void *) in;
++    cryp.dst = (void *) out;
++    cryp.auth_src = state->aad;
++    cryp.auth_len = state->aad_len;
++
++    cryp.op = EVP_CIPHER_CTX_encrypting(ctx) ? COP_ENCRYPT : COP_DECRYPT;
++
++    if (ioctl(cfd, CIOCAUTHCRYPT, &cryp) == -1) {
++        /*
++         * XXX need better errror handling this can fail for a number of
++         * different reasons.
++         */
++        return 0;
++    }
++
++    if (EVP_CIPHER_CTX_iv_length(ctx) > 0) {
++        if (EVP_CIPHER_CTX_encrypting(ctx))
++            iiv = out + len - EVP_CIPHER_CTX_iv_length(ctx);
++        else
++            iiv = save_iv;
++
++        memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), iiv,
++               EVP_CIPHER_CTX_iv_length(ctx));
++    }
++    return 1;
++}
++
++static int cryptodev_cbc_hmac_sha1_ctrl(EVP_CIPHER_CTX *ctx, int type,
++                                        int arg, void *ptr)
++{
++    switch (type) {
++    case EVP_CTRL_AEAD_SET_MAC_KEY:
++        {
++        /* TODO: what happens with hmac keys larger than 64 bytes? */
++            struct cipher_ctx *state =
++                EVP_CIPHER_CTX_get_cipher_data(ctx);
++            struct session_op *sess = &state->sess;
++
++            /* the rest should have been set in cryptodev_init_aead_key */
++            sess->mackey = ptr;
++            sess->mackeylen = arg;
++            if (ioctl(cfd, CIOCGSESSION, sess) == -1)
++                return 0;
++
++            return 1;
++        }
++    case EVP_CTRL_AEAD_TLS1_AAD:
++        {
++            /* ptr points to the associated data buffer of 13 bytes */
++            struct cipher_ctx *state =
++                EVP_CIPHER_CTX_get_cipher_data(ctx);
++            unsigned char *p = ptr;
++            unsigned int cryptlen = p[arg - 2] << 8 | p[arg - 1];
++            unsigned int maclen;
++            unsigned int blocksize = EVP_CIPHER_CTX_block_size(ctx);
++            int ret;
++
++            state->tls_ver = p[arg - 4] << 8 | p[arg - 3];
++            state->aad = ptr;
++            state->aad_len = arg;
++
++            /* TODO: this should be an extension of EVP_CIPHER struct */
++            switch (EVP_CIPHER_CTX_nid(ctx)) {
++            case NID_aes_128_cbc_hmac_sha1:
++            case NID_aes_256_cbc_hmac_sha1:
++                maclen = SHA_DIGEST_LENGTH;
++                break;
++            case NID_aes_128_cbc_hmac_sha256:
++            case NID_aes_256_cbc_hmac_sha256:
++                maclen = SHA256_DIGEST_LENGTH;
++                break;
++            default:
++            /*
++             * Only above 4 supported NIDs are used to enter to this
++             * function. If any other NID reaches this function,
++             * there's a grave coding error further down.
++             */
++                assert("Code that never should be reached" == NULL);
++                return -1;
++            }
++
++            /* space required for encryption (not only TLS padding) */
++            if (EVP_CIPHER_CTX_encrypting(ctx)) {
++                if (state->tls_ver >= TLS1_1_VERSION) {
++                    p[arg - 2] = (cryptlen - blocksize) >> 8;
++                    p[arg - 1] = (cryptlen - blocksize);
++                }
++                ret = (int)(((cryptlen + maclen +
++                      blocksize) & -blocksize) - cryptlen);
++            } else {
++                if (state->tls_ver >= TLS1_1_VERSION) {
++                    cryptlen -= blocksize;
++                    p[arg - 2] = cryptlen >> 8;
++                    p[arg - 1] = cryptlen;
++                }
++                ret = maclen;
++            }
++            state->len = cryptlen;
++            return ret;
++        }
++    default:
++        return -1;
++    }
++}
++
+ /*
+  * Following are the three necessary functions to map OpenSSL functionality
+  * with cryptodev.
+@@ -455,6 +664,7 @@ static void prepare_cipher_methods(void)
+          */
+         sess.cipher = cipher_data[i].devcryptoid;
+         sess.keylen = cipher_data[i].keylen;
++        sess.mackeylen = cipher_data[i].mackeylen;
+ 
+ #ifdef CIOCGSESSION2
+         /*
+@@ -484,6 +694,15 @@ static void prepare_cipher_methods(void)
+         do_cipher = (cipher_mode == EVP_CIPH_CTR_MODE ?
+                                               ctr_do_cipher :
+                                               cipher_do_cipher);
++        if (cipher_data[i].nid == NID_aes_128_cbc_hmac_sha1
++                || cipher_data[i].nid == NID_aes_256_cbc_hmac_sha1
++                || cipher_data[i].nid == NID_aes_128_cbc_hmac_sha256
++                || cipher_data[i].nid == NID_aes_256_cbc_hmac_sha256) {
++                init = cryptodev_init_aead_key;
++                do_cipher = cryptodev_aead_cipher;
++                ctrl = cryptodev_cbc_hmac_sha1_ctrl;
++                flags = cipher_data[i].flags;
++        }
+         if ((known_cipher_methods[i] = EVP_CIPHER_meth_new(cipher_data[i].nid,
+                  cipher_mode == EVP_CIPH_CTR_MODE ? 1 : cipher_data[i].blocksize,
+                  cipher_data[i].keylen))
+@@ -525,10 +744,15 @@ static void prepare_cipher_methods(void)
+             }
+ #endif /* CIOCGSESSINFO */
+         }
++        if (cipher_data[i].nid == NID_aes_128_cbc_hmac_sha1
++                || cipher_data[i].nid == NID_aes_256_cbc_hmac_sha1
++                || cipher_data[i].nid == NID_aes_128_cbc_hmac_sha256
++                || cipher_data[i].nid == NID_aes_256_cbc_hmac_sha256)
++                EVP_add_cipher(known_cipher_methods[i]);
++
+         ioctl(cfd, CIOCFSESSION, &sess.ses);
+-        if (devcrypto_test_cipher(i)) {
++        if (devcrypto_test_cipher(i)) 
+             known_cipher_nids[known_cipher_nids_amount++] = cipher_data[i].nid;
+-        }
+     }
+ }
+ 
+-- 
+2.34.1
+

--- a/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/openssl-3.0-add-Kernel-TLS-configuration.patch
+++ b/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl/openssl-3.0-add-Kernel-TLS-configuration.patch
@@ -1,0 +1,34 @@
+From 24254454e5f5fc503b5e4cc1fa8c6d9b1a3ae9ba Mon Sep 17 00:00:00 2001
+From: Gaurav Jain <gaurav.jain@nxp.com>
+Date: Wed, 19 Jan 2022 15:45:29 +0530
+Subject: [PATCH] openssl 3.0: add Kernel TLS configuration
+
+Upstream-Status: Inappropriate [i.MX, Layerscape specific]
+Signed-off-by: Gaurav Jain <gaurav.jain@nxp.com>
+---
+ apps/openssl.cnf | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 03330e0120..ec18df388e 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -30,6 +30,15 @@ oid_section = new_oids
+ # (Alternatively, use a configuration file that has only
+ # X.509v3 extensions in its main [= default] section.)
+ 
++[ openssl_init ]
++ssl_conf = ssl_configuration
++
++[ ssl_configuration ]
++ktls = ktls_conf
++
++[ ktls_conf ]
++Options = KTLS
++
+ [ new_oids ]
+ # We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+ # Add a simple OID like this:
+-- 
+2.25.1
+

--- a/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-balena-bootloader/0105-add-mdpcb-m2tpm-device-tree.patch
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-balena-bootloader/0105-add-mdpcb-m2tpm-device-tree.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shaun Mulligan <shaun@balena.io>
+Date: Mon, 21 Apr 2026 12:00:00 +0000
+Subject: [PATCH] arm64: dts: compulab: add iot-gate-imx8plus-mdpcb-m2tpm device tree
+
+Add the MDPCB-M2TPM expansion board device tree variant for the
+IOT-GATE-IMX8PLUS. This DTS configures the TPM (Infineon SLB9670)
+on SPI, custom GPIO and PWM pin muxing, and an M.2 EEPROM on I2C5.
+
+Upstream-status: Pending
+Signed-off-by: Shaun Mulligan <shaun@balena.io>
+---
+ .../dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts | 93 +++++++++++++++++++
+ arch/arm64/boot/dts/compulab/Makefile               |  1 +
+ 2 files changed, 94 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+
+diff --git a/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+@@ -0,0 +1,93 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2022 CompuLab Ltd
++ * Modified and renamed from original "iot-gate-imx8plus-m2tpm.dts" on 2026-04-17 to add custom pin configuration
++ */
++
++#include "iot-gate-imx8plus.dts"
++
++/* IOT-GATE-IMX8PLUS with TPM extension module in M.2 Expansion Connector */
++
++/ {
++	model = "MDPCB-M2TPM Expansion Board";
++
++	tpm_nreset: tpm-nreset {
++		compatible = "gpio-reset";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm_nrst>;
++		reset-gpios = <&gpio2 14 GPIO_ACTIVE_HIGH>;
++		#reset-cells = <0>;
++		initially-in-reset;
++	};
++};
++
++&gpio2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_gpio2>;
++	status = "okay";
++};
++
++&ecspi2 {
++	status = "okay";
++
++	/delete-node/ spidev2@0;
++
++	slb9670: slb9670-ecspi2@0 {
++		resets = <&tpm_nreset>;
++		compatible = "infineon,slb9670", "tcg,tpm_tis-spi";
++		reg = <0>;
++		spi-max-frequency = <5000000>;
++		status = "okay";
++	};
++};
++
++&pwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm3>;
++	status = "okay";
++};
++
++&i2c5 {
++	status = "okay";
++
++	eeprom_m2: eeprom-i2c5@54 {
++		compatible = "atmel,24c08";
++		pagesize = <16>;
++		reg = <0x54>;
++		status = "okay";
++	};
++};
++
++&i2c6 {
++	status = "disabled";
++};
++
++&usdhc2 {
++	status = "disabled";
++};
++
++&iomuxc {
++	pinctrl_tpm_nrst: tpmnrstgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CMD__GPIO2_IO14       0x19
++		>;
++	};
++
++		pinctrl_gpio2: gpio2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__GPIO2_IO13       0x100
++			MX8MP_IOMUXC_SD2_DATA0__GPIO2_IO15     0x100
++			MX8MP_IOMUXC_SD2_DATA1__GPIO2_IO16     0x100
++			MX8MP_IOMUXC_SD2_DATA2__GPIO2_IO17     0x100
++			MX8MP_IOMUXC_SD2_DATA3__GPIO2_IO18     0x100
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19   0x100
++			MX8MP_IOMUXC_GPIO1_IO04__GPIO1_IO04    0x100  /* Pin doesn't need config */
++		>;
++	};
++
++		pinctrl_pwm3: pwm3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXC__PWM3_OUT        0x116  /* P5-09 */
++		>;
++	};
++};
+diff --git a/arch/arm64/boot/dts/compulab/Makefile b/arch/arm64/boot/dts/compulab/Makefile
+index aabbccdd..eeff0011 100644
+--- a/arch/arm64/boot/dts/compulab/Makefile
++++ b/arch/arm64/boot/dts/compulab/Makefile
+@@ -21,6 +21,7 @@
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-usbdev.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-m2tpm.dtb
++dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-mdpcb-m2tpm.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-brkout_pwm_gpio.dtb
+ 
+ dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus.dtb
+-- 
+2.37.2

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-balena-bootloader_5.15.32.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-balena-bootloader_5.15.32.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append = " \
     file://arm64-kexec_file-use-more-system-keyrings-to-verify-.patch \
     file://kexec-KEYS-make-the-code-in-bzImage64_verify_sig-gen.patch \
     file://0204-add-iot-gate-imx8plus-m7-device-tree.patch \
+    file://0105-add-mdpcb-m2tpm-device-tree.patch \
 "
 
 PACKAGESPLITFUNCS:remove = "split_kernel_module_packages"

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0104-add-71MHz-pixel-clock-to-samsung-hdmi-phy.patch
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0104-add-71MHz-pixel-clock-to-samsung-hdmi-phy.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shaun Mulligan <shaun@balena.io>
+Date: Wed, 16 Apr 2026 12:00:00 +0000
+Subject: [PATCH] phy: freescale: samsung-hdmi: add 71MHz pixel clock entry
+
+Add a 71MHz pixel clock frequency entry to the samsung_phy_pll_cfg[]
+table to support 1280x800 displays via HDMI on the IOT-GATE-IMX8PLUS.
+
+The PLL register values were provided by NXP and produce exactly
+71.000000 MHz using fractional-N PLL parameters:
+Customer-tested and validated register values
+for 71MHz output on 1280x800 HDMI displays.
+
+Upstream-status: Pending
+Signed-off-by: Shaun Mulligan <shaun@balena.io>
+---
+ drivers/phy/freescale/phy-fsl-samsung-hdmi.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/phy/freescale/phy-fsl-samsung-hdmi.c b/drivers/phy/freescale/phy-fsl-samsung-hdmi.c
+index 1111111..2222222 100644
+--- a/drivers/phy/freescale/phy-fsl-samsung-hdmi.c
++++ b/drivers/phy/freescale/phy-fsl-samsung-hdmi.c
+@@ -344,6 +344,15 @@
+ 			0x00, 0xE0, 0x83, 0x0F, 0x3E, 0xF8, 0x00, 0x00,
+ 		},
+ 	}, {
++		71000000, {
++			0x00, 0xD1, 0x3B, 0x30, 0xBB, 0x08, 0x81, 0x41,
++			0x4F, 0x30, 0x33, 0x65, 0x10, 0xAE, 0x24, 0x80,
++			0x6C, 0xF2, 0x67, 0x00, 0x10, 0x85, 0x30, 0x32,
++			0x60, 0x8F, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
++			0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++			0x00, 0xE0, 0x83, 0x0F, 0x3E, 0xF8, 0x00, 0x00,
++		},
++	}, {
+ 		72000000, {
+ 			0x00, 0xD1, 0x5A, 0x50, 0x00, 0x00, 0x80, 0x00,
+ 			0x4F, 0x30, 0x33, 0x65, 0x10, 0xAB, 0x24, 0x80,
+-- 
+2.37.2

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0105-add-mdpcb-m2tpm-device-tree.patch
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0105-add-mdpcb-m2tpm-device-tree.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shaun Mulligan <shaun@balena.io>
+Date: Mon, 21 Apr 2026 12:00:00 +0000
+Subject: [PATCH] arm64: dts: compulab: add iot-gate-imx8plus-mdpcb-m2tpm device tree
+
+Add the MDPCB-M2TPM expansion board device tree variant for the
+IOT-GATE-IMX8PLUS. This DTS configures the TPM (Infineon SLB9670)
+on SPI, custom GPIO and PWM pin muxing, and an M.2 EEPROM on I2C5.
+
+Upstream-status: Pending
+Signed-off-by: Shaun Mulligan <shaun@balena.io>
+---
+ .../dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts | 93 +++++++++++++++++++
+ arch/arm64/boot/dts/compulab/Makefile               |  1 +
+ 2 files changed, 94 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+
+diff --git a/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-mdpcb-m2tpm.dts
+@@ -0,0 +1,93 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2022 CompuLab Ltd
++ * Modified and renamed from original "iot-gate-imx8plus-m2tpm.dts" on 2026-04-17 to add custom pin configuration
++ */
++
++#include "iot-gate-imx8plus.dts"
++
++/* IOT-GATE-IMX8PLUS with TPM extension module in M.2 Expansion Connector */
++
++/ {
++	model = "MDPCB-M2TPM Expansion Board";
++
++	tpm_nreset: tpm-nreset {
++		compatible = "gpio-reset";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_tpm_nrst>;
++		reset-gpios = <&gpio2 14 GPIO_ACTIVE_HIGH>;
++		#reset-cells = <0>;
++		initially-in-reset;
++	};
++};
++
++&gpio2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_gpio2>;
++	status = "okay";
++};
++
++&ecspi2 {
++	status = "okay";
++
++	/delete-node/ spidev2@0;
++
++	slb9670: slb9670-ecspi2@0 {
++		resets = <&tpm_nreset>;
++		compatible = "infineon,slb9670", "tcg,tpm_tis-spi";
++		reg = <0>;
++		spi-max-frequency = <5000000>;
++		status = "okay";
++	};
++};
++
++&pwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm3>;
++	status = "okay";
++};
++
++&i2c5 {
++	status = "okay";
++
++	eeprom_m2: eeprom-i2c5@54 {
++		compatible = "atmel,24c08";
++		pagesize = <16>;
++		reg = <0x54>;
++		status = "okay";
++	};
++};
++
++&i2c6 {
++	status = "disabled";
++};
++
++&usdhc2 {
++	status = "disabled";
++};
++
++&iomuxc {
++	pinctrl_tpm_nrst: tpmnrstgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CMD__GPIO2_IO14       0x19
++		>;
++	};
++
++		pinctrl_gpio2: gpio2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__GPIO2_IO13       0x100
++			MX8MP_IOMUXC_SD2_DATA0__GPIO2_IO15     0x100
++			MX8MP_IOMUXC_SD2_DATA1__GPIO2_IO16     0x100
++			MX8MP_IOMUXC_SD2_DATA2__GPIO2_IO17     0x100
++			MX8MP_IOMUXC_SD2_DATA3__GPIO2_IO18     0x100
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19   0x100
++			MX8MP_IOMUXC_GPIO1_IO04__GPIO1_IO04    0x100  /* Pin doesn't need config */
++		>;
++	};
++
++		pinctrl_pwm3: pwm3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXC__PWM3_OUT        0x116  /* P5-09 */
++		>;
++	};
++};
+diff --git a/arch/arm64/boot/dts/compulab/Makefile b/arch/arm64/boot/dts/compulab/Makefile
+index aabbccdd..eeff0011 100644
+--- a/arch/arm64/boot/dts/compulab/Makefile
++++ b/arch/arm64/boot/dts/compulab/Makefile
+@@ -21,6 +21,7 @@
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-usbdev.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-m2tpm.dtb
++dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-mdpcb-m2tpm.dtb
+ 
+ dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus.dtb
+ dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus_mipi-csi1.dtb
+-- 
+2.37.2

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0204-add-iot-gate-imx8plus-m7-device-tree.patch
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab/0204-add-iot-gate-imx8plus-m7-device-tree.patch
@@ -18,20 +18,20 @@ Signed-off-by: Shaun Mulligan <shaun@balena.io>
  create mode 100644 arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m7.dts
 
 diff --git a/arch/arm64/boot/dts/compulab/Makefile b/arch/arm64/boot/dts/compulab/Makefile
-index 60205dd04b1f..0eddb8bdb36c 100644
+index 06c644a89f2a..b3cc8a2b803b 100644
 --- a/arch/arm64/boot/dts/compulab/Makefile
 +++ b/arch/arm64/boot/dts/compulab/Makefile
-@@ -21,6 +21,7 @@ dtb-$(CONFIG_ARCH_MXC) += ucm-imx8m-plus-headless.dtb
- dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus.dtb
+@@ -22,6 +22,7 @@ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus.dtb
  dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-usbdev.dtb
  dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-m2tpm.dtb
+ dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-mdpcb-m2tpm.dtb
 +dtb-$(CONFIG_ARCH_MXC) += iot-gate-imx8plus-m7.dtb
  
  dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus.dtb
  dtb-$(CONFIG_ARCH_MXC) += som-imx8m-plus_mipi-csi1.dtb
 diff --git a/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m7.dts b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m7.dts
 new file mode 100644
-index 000000000000..2e246d8eee6f
+index 000000000000..80d46f4800f0
 --- /dev/null
 +++ b/arch/arm64/boot/dts/compulab/iot-gate-imx8plus-m7.dts
 @@ -0,0 +1,144 @@
@@ -179,6 +179,6 @@ index 000000000000..2e246d8eee6f
 +&gpio4 {
 +	gpio-reserved-ranges = <12 1>, <29 3>;
 +};
---
+-- 
 2.34.1
 

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -16,6 +16,7 @@ SRC_URI:append = " \
     file://0102-compulab-iot-gate-imx8plus-add-LED-pins-configuratio.patch \
     file://0103-compulab-iot-gate-imx8plus-fec-update-drive-strength.patch \
     file://0104-add-71MHz-pixel-clock-to-samsung-hdmi-phy.patch \
+    file://0105-add-mdpcb-m2tpm-device-tree.patch \
 "
 
 # M7 remoteproc device tree (kernel 5.15.71 already has imx_rproc fixes)

--- a/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/layers/meta-balena-imx8mplus/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI:append = " \
     file://0101-net-phy-realtek-RTL8211F-add-LED-mode-configuration-.patch \
     file://0102-compulab-iot-gate-imx8plus-add-LED-pins-configuratio.patch \
     file://0103-compulab-iot-gate-imx8plus-fec-update-drive-strength.patch \
+    file://0104-add-71MHz-pixel-clock-to-samsung-hdmi-phy.patch \
 "
 
 # M7 remoteproc device tree (kernel 5.15.71 already has imx_rproc fixes)


### PR DESCRIPTION
This PR does the following:
  - Add 71MHz pixel clock entry to the Samsung HDMI PHY driver to support 1280x800 displays via HDMI. PLL register values have been tested and validated on the IOT-GATE-imx8plus hardware.                                   
  - Add iot-gate-imx8plus-mdpcb-m2tpm device tree for the MDPCB-M2TPM expansion board (Infineon SLB9670 TPM on SPI, GPIO/PWM pin muxing, M.2 EEPROM on I2C5). The DTB is deployed to the boot  
  partition and can be enabled by setting `BALENA_HOST_EXTLINUX_fdt=iot-gate-imx8plus-mdpcb-m2tpm.dtb` on the device or fleet configuration page.   